### PR TITLE
Fix for board catalog truncation

### DIFF
--- a/boardtab.ui
+++ b/boardtab.ui
@@ -123,18 +123,12 @@
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
-      <property name="maximumSize">
-       <size>
-        <width>16777215</width>
-        <height>16777215</height>
-       </size>
-      </property>
       <layout class="QVBoxLayout" name="threads">
        <property name="spacing">
         <number>11</number>
        </property>
        <property name="sizeConstraint">
-        <enum>QLayout::SetMinAndMaxSize</enum>
+        <enum>QLayout::SetMinimumSize</enum>
        </property>
        <property name="leftMargin">
         <number>0</number>

--- a/boardtabhelper.cpp
+++ b/boardtabhelper.cpp
@@ -153,7 +153,7 @@ QJsonArray BoardTabHelper::filterThreads(QByteArray &rep){
 		QJsonArray allThreads = api->catalogArray(rep);
 		int numPages = allThreads.size();
 		//-5 for some reason catalog goes blank on last 5 pages
-		for(int i=0;i<numPages-5;i++){
+		for(int i=0;i<numPages;i++){
 			QJsonArray pageThreads = api->catalogPageArray(allThreads,i);
 			int numThreads = pageThreads.size();
 			for(int j=0;j<numThreads;j++){


### PR DESCRIPTION
Due to putting a size restriction in the boardtab.ui, only 128 posts
would fit in the catalog view. Removing the size restriction from the UI
allows for all catalog pages to be fetched.